### PR TITLE
Replace sudo command with become

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure packages database is up to date
-  sudo: yes
+  become: yes
   apt: update_cache=yes
 
 - name: Install Redis


### PR DESCRIPTION
Issue: [phansible/phansible/issues/273](https://github.com/phansible/phansible/issues/273)
Replace `sudo` command `become`since `sudo` will be deprecated.
